### PR TITLE
Add host.name attribute to OpenTelemetry resource configuration.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,6 +377,7 @@ impl<C, R, U, P, E> AppInsights<WithConnectionString, C, R, U, P, E> {
         let config = Config::default().with_resource(opentelemetry_sdk::Resource::new(vec![
             KeyValue::new("service.namespace", namespace.as_ref().to_owned()),
             KeyValue::new("service.name", name.as_ref().to_owned()),
+            KeyValue::new("host.name", servername.as_ref().to_owned()),
             // KeyValue::new("ai.cloud.roleInstance", server_name.clone()), // Azure-specific resource attribute
             KeyValue::new("service.instance.id", servername.as_ref().to_owned()),  // General OpenTelemetry attribute
         ]));


### PR DESCRIPTION
after much investigation into the matter of quick pulse showing all the instances with this library as the same pod name, apperantly opentelemetry-application-insights using this to set the name of instance